### PR TITLE
Add speed parameter to TTS playground

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -69,15 +69,11 @@
             <option value="tts-1">tts-1</option>
             <option value="tts-1-hd" selected>tts-1-hd</option>
             </select>
+          <label for="speedInput" class="form-label" id="speedLabel">Speed</label>
           <input
             type="range"
             id="speedInput"
-            class="form-control mb-3"
-            min="0.25"
-            max="4.0"
-            step="0.01"
-            value="1.0"
-            title="Select Speed"
+            class="form-range mb-3"
           />
           <input
             type="text"

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,16 @@
             <option value="tts-1-hd" selected>tts-1-hd</option>
             </select>
           <input
+            type="range"
+            id="speedInput"
+            class="form-control mb-3"
+            min="0.25"
+            max="4.0"
+            step="0.01"
+            value="1.0"
+            title="Select Speed"
+          />
+          <input
             type="text"
             id="apiKeyInput"
             class="form-control mb-3"

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const delay = (ms) => {
 //#endregion
 
 const generateCacheKey = async (text, config, type = "audio") => {
-  return `${type}-${config.model}-${config.voice}-${await sha256(text)}`;
+  return `${type}-${config.model}-${config.voice}-${config.speed}-${await sha256(text)}`;
 };
 
 // Function to split the text into meaningful chunks
@@ -196,8 +196,12 @@ const updatePricing = async () => {
   const text = document.getElementById("textInput").value;
   const voice = document.getElementById("voiceSelect").value;
   const model = document.getElementById("modelSelect").value;
+  const speed = document.getElementById("speedInput").value;
 
-  const cacheKey = await generateCacheKey(text, { model, voice });
+  // Also update speed label with speed
+  document.getElementById("speedLabel").innerText = `Speed (${speed}x)`;
+
+  const cacheKey = await generateCacheKey(text, { model, voice, speed });
 
   // Check cache first
   let cachedBase64 = localStorage.getItem(cacheKey);
@@ -215,7 +219,7 @@ const updatePricing = async () => {
   ).innerText = `Convert to Speech (¢${cents.toFixed(2)})`;
 };
 
-const init = () => {
+const init = async () => {
   // Load the API key from cache
   const apiKey = localStorage.getItem("apiKey");
   if (apiKey) {
@@ -229,12 +233,18 @@ const init = () => {
   document
     .getElementById("modelSelect")
     .addEventListener("change", updatePricing);
-  document.getElementById("speedInput").addEventListener("input", updatePricing);
-  document.getElementById("convertBtn").addEventListener("click", convert);
+  document
+    .getElementById("speedInput")
+    .addEventListener("input", updatePricing);
+  document
+    .getElementById("convertBtn")
+    .addEventListener("click", convert);
 
   document.getElementById("speedInput").min = "0.25";
   document.getElementById("speedInput").max = "4.0";
+  document.getElementById("speedInput").step = "0.05";
   document.getElementById("speedInput").value = "1.0";
+  await updatePricing();
 };
 
 init();

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,7 @@ const fetchAndConcatenateAudio = async (
           model: config.model,
           input: chunk,
           voice: config.voice,
+          speed: config.speed,
         }),
       });
 
@@ -142,8 +143,9 @@ const convert = async () => {
   const voice = document.getElementById("voiceSelect").value;
   const model = document.getElementById("modelSelect").value;
   const apiKey = document.getElementById("apiKeyInput").value;
+  const speed = parseFloat(document.getElementById("speedInput").value);
 
-  const cacheKey = await generateCacheKey(text, { voice, model });
+  const cacheKey = await generateCacheKey(text, { voice, model, speed });
 
   // Check cache first
   let cachedBase64 = localStorage.getItem(cacheKey);
@@ -164,7 +166,7 @@ const convert = async () => {
     const textChunks = splitText(text);
     audioBlob = await fetchAndConcatenateAudio(
       textChunks,
-      { voice, model, apiKey },
+      { voice, model, apiKey, speed },
       (progress) => {
         button.innerText = `Converting... (${(progress * 100).toFixed(0)}%)`;
       }
@@ -227,7 +229,12 @@ const init = () => {
   document
     .getElementById("modelSelect")
     .addEventListener("change", updatePricing);
+  document.getElementById("speedInput").addEventListener("input", updatePricing);
   document.getElementById("convertBtn").addEventListener("click", convert);
+
+  document.getElementById("speedInput").min = "0.25";
+  document.getElementById("speedInput").max = "4.0";
+  document.getElementById("speedInput").value = "1.0";
 };
 
 init();


### PR DESCRIPTION
Add a speed configuration slider to the UI for generated audio. Closes #2.

* **src/index.html**
  - Add an input range element with id `speedInput` for speed configuration below the model selection widget.

* **src/index.js**
  - Add a `speed` parameter to the API request in the `fetchAndConcatenateAudio` function.
  - Add a `speed` parameter to the `convert` function.
  - Add an event listener to update the speed value from the `speedInput` element.
  - Set the range of the slider from 0.25 to 4.0 in the `init` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LinqLover/simple-openai-tts-playground/issues/2?shareId=0d80a276-529b-4b07-bfec-7d386476e4e1).