### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimal yet working prototype. Feel free to propose features and contribute PRs!
 ## Current Features
 
 - Select different voices and models
-- Automatic division of long textes
+- Automatic division of long texts
 - Price display
 - Caching of audio files (in local browser storage)
 


### PR DESCRIPTION
## Summary
- fix a typo in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f783c60c08324bea8eb0a33ce198d